### PR TITLE
build: Suppress support for Angular 22.x and TypeScript 7.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,15 +13,15 @@ updates:
       - dependency-name: 'eslint-plugin-cypress'
         versions: ['4.x', '5.x', '6.x']
       - dependency-name: '@angular/*'
-        versions: ['18.x', '19.x', '20.x', '21.x']
+        versions: ['18.x', '19.x', '20.x', '21.x', '22.x']
       - dependency-name: '@angular-devkit/build-angular'
-        versions: ['18.x', '19.x', '20.x', '21.x']
+        versions: ['18.x', '19.x', '20.x', '21.x', '22.x']
       - dependency-name: '@angular-eslint/*'
-        versions: ['18.x', '19.x', '20.x', '21.x']
+        versions: ['18.x', '19.x', '20.x', '21.x', '22.x']
       - dependency-name: 'ng-packagr'
-        versions: ['18.x', '19.x', '20.x', '21.x']
+        versions: ['18.x', '19.x', '20.x', '21.x', '22.x']
       - dependency-name: 'typescript'
-        versions: ['5.5.x', '5.6.x', '5.7.x', '5.8.x', '5.9.x', '6.x']
+        versions: ['5.5.x', '5.6.x', '5.7.x', '5.8.x', '5.9.x', '6.x', '7.x']
       - dependency-name: 'zone'
         versions: ['0.15.x', '0.16.x']
       - dependency-name: 'cypress'


### PR DESCRIPTION
cannot update angular by updating a single package