### PR TITLE
build Add @types/node dependencies to dependabot config to ignore newer node versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,8 @@ updates:
         versions: ['4.x', '5.x']
       - dependency-name: '@cypress/webpack-preprocessor'
         versions: ['7.x']
+      - dependency-name: '@types/node'
+        versions: ['21.x', '22.x', '23.x', '24.x', '25.x', '26.x']
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
Add @types/node to dependabot configuration to ignore dependency versions 21.x to 26.x (not compatible with angular@17).
